### PR TITLE
Fix for browsers without ES6 support

### DIFF
--- a/muk_web_utils/static/src/js/underscore.js
+++ b/muk_web_utils/static/src/js/underscore.js
@@ -1,5 +1,5 @@
 /**********************************************************************************
-*
+* 
 *    Copyright (C) 2018 MuK IT GmbH
 *
 *    This program is free software: you can redistribute it and/or modify
@@ -19,8 +19,8 @@
 
 _.mixin({
 	memoizeDebounce: function(func, wait, options) {
-        wait = (typeof wait !== 'undefined') ? wait : 0;
-        options = (typeof options !== 'undefined') ? options : {};
+		wait = (typeof wait !== 'undefined') ? wait : 0;
+		options = (typeof options !== 'undefined') ? options : {};
     	var mem = _.memoize(function() {
     		return _.debounce(func, wait, options)
     	}, options.resolver);
@@ -32,8 +32,8 @@ _.mixin({
 
 _.mixin({
     memoizeThrottle: function(func, wait, options) {
-        wait = (typeof wait !== 'undefined') ? wait : 0;
-        options = (typeof options !== 'undefined') ? options : {};
+		wait = (typeof wait !== 'undefined') ? wait : 0;
+		options = (typeof options !== 'undefined') ? options : {};
     	var mem = _.memoize(function() {
     		return _.throttle(func, wait, options)
     	}, options.resolver);

--- a/muk_web_utils/static/src/js/underscore.js
+++ b/muk_web_utils/static/src/js/underscore.js
@@ -18,7 +18,9 @@
 **********************************************************************************/
 
 _.mixin({
-	memoizeDebounce: function(func, wait=0, options={}) {
+	memoizeDebounce: function(func, wait, options) {
+		wait = (typeof wait !== 'undefined') ? wait : 0;
+        options = (typeof options !== 'undefined') ? options : {};
     	var mem = _.memoize(function() {
     		return _.debounce(func, wait, options)
     	}, options.resolver);
@@ -29,7 +31,9 @@ _.mixin({
 });
 
 _.mixin({
-    memoizeThrottle: function(func, wait=0, options={}) {
+    memoizeThrottle: function(func, wait, options) {
+		wait = (typeof wait !== 'undefined') ? wait : 0;
+		options = (typeof options !== 'undefined') ? options : {};
     	var mem = _.memoize(function() {
     		return _.throttle(func, wait, options)
     	}, options.resolver);

--- a/muk_web_utils/static/src/js/underscore.js
+++ b/muk_web_utils/static/src/js/underscore.js
@@ -1,5 +1,5 @@
 /**********************************************************************************
-* 
+*
 *    Copyright (C) 2018 MuK IT GmbH
 *
 *    This program is free software: you can redistribute it and/or modify
@@ -19,7 +19,7 @@
 
 _.mixin({
 	memoizeDebounce: function(func, wait, options) {
-		wait = (typeof wait !== 'undefined') ? wait : 0;
+        wait = (typeof wait !== 'undefined') ? wait : 0;
         options = (typeof options !== 'undefined') ? options : {};
     	var mem = _.memoize(function() {
     		return _.debounce(func, wait, options)
@@ -32,8 +32,8 @@ _.mixin({
 
 _.mixin({
     memoizeThrottle: function(func, wait, options) {
-		wait = (typeof wait !== 'undefined') ? wait : 0;
-		options = (typeof options !== 'undefined') ? options : {};
+        wait = (typeof wait !== 'undefined') ? wait : 0;
+        options = (typeof options !== 'undefined') ? options : {};
     	var mem = _.memoize(function() {
     		return _.throttle(func, wait, options)
     	}, options.resolver);


### PR DESCRIPTION
Odoo javascript would break with your module on older browsers without ES6 support. (Like safari on iOS 9 in our example.)
I changed the methods to work without ES6 default parameter feature.