### PR TITLE
Small tweak to have background dependent text color for the app-name. 

### DIFF
--- a/muk_web_theme/static/src/scss/apps.scss
+++ b/muk_web_theme/static/src/scss/apps.scss
@@ -67,7 +67,8 @@
 		    width: 100%;
 		}
 		.o-app-name {
-			color: $gray-100; 
+			color: $gray-100;
+			mix-blend-mode: difference;
 		}
 		.form-row {
 		    width: 100%;


### PR DESCRIPTION
Now you can choose any picture of any color as backgroud and you can be sure you are able to read the app names.