### PR TITLE
PR for issue #60

### DIFF
--- a/muk_web_preview_msoffice/static/src/js/preview_handler.js
+++ b/muk_web_preview_msoffice/static/src/js/preview_handler.js
@@ -117,6 +117,19 @@ var ExcelHandler = PreviewHandler.BaseHandler.extend({
 		    			var $pane = $('<div/>');
 		    			$pane.addClass('tab-pane table-container');
 		    			$pane.attr('id', 'sheet-' + index);
+					var maximum_arrs = 1;
+					sheet.forEach(function (arr) {
+						if(arr.length>maximum_arrs){
+							maximum_arrs = arr.length;
+						}
+					});
+					sheet.forEach(function (arr) {
+						if(arr.length<maximum_arrs){
+							for (var i = arr.length; i < maximum_arrs; i++) {
+								arr.push("");
+							}
+						}
+					});
 		    			$pane.handsontable({
 						    data: sheet,
 						    rowHeaders: true,


### PR DESCRIPTION
If the number of columns in the first row is not equal to the number of others, it is not converted correctly, in short, it converts only the number of columns in each row that the first row contains.
SOLVED.
In muk_web_preview_msoffice/static/src/js/preview_handler.js after line 119 ("""$pane.attr('id', 'sheet-' + index);""") add following:
"""var maximum_arrs = 1;
sheet.forEach(function (arr) {
if(arr.length>maximum_arrs){
maximum_arrs = arr.length;
}
});
sheet.forEach(function (arr) {
if(arr.length<maximum_arrs){
for (var i = arr.length; i < maximum_arrs; i++) {
arr.push("");
}
}
});"""