### PR TITLE
[FIX] Error refresh view list and kanban

### DIFF
--- a/muk_web_client_refresh/static/src/js/client_refresh.js
+++ b/muk_web_client_refresh/static/src/js/client_refresh.js
@@ -49,10 +49,10 @@ WebClient.include({
             	if(active_view.type === "form" && message.ids.includes(widget.env.currentId)) {
             		controller.reload();
             	} else if(active_view.type === "list" &&
-            			(message.create || _.intersection(message.ids, widget.env.ids) >= 1)) {
+            			(message.create || _.intersection(message.ids, widget.env.ids).length > 0)) {
             		controller.reload();
             	} else if(active_view.type === "kanban" &&
-            			(message.create || _.intersection(message.ids, widget.env.ids) >= 1)) {
+            			(message.create || _.intersection(message.ids, widget.env.ids).length > 0)) {
             		controller.reload();
             	}
             }


### PR DESCRIPTION
_.intersection returns a dictionary which is then compared to an integer. We think it should be compared to the length of that dictionary.