### PR TITLE
muk_web_theme: Fixed an issue in the __manifest__ file that caused the error "Template 'muk_web_theme.AppsBarMenu' not found" on installation

### DIFF
--- a/muk_web_theme/__manifest__.py
+++ b/muk_web_theme/__manifest__.py
@@ -47,7 +47,12 @@
     ],
     "qweb": [
         "static/src/components/control_panel.xml",
-        "static/src/xml/*.xml",
+        "static/src/xml/apps.xml",
+        "static/src/xml/appsbar.xml",
+        "static/src/xml/base.xml",
+        "static/src/xml/navbar.xml",
+        "static/src/xml/shortcuts.xml",
+        "static/src/xml/views.xml",
     ],
     "images": [
         'static/description/banner.png',


### PR DESCRIPTION
muk_web_theme: Fixed an issue in the __manifest__ file that caused the error "Template 'muk_web_theme.AppsBarMenu' not found" on installation.

the *.xml line does not work.